### PR TITLE
Creates an ItemAttributesRQ from a single Tag-Annotation using the colon

### DIFF
--- a/src/test/java/com/epam/reportportal/cucumber/CodeRefTest.java
+++ b/src/test/java/com/epam/reportportal/cucumber/CodeRefTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -92,7 +91,7 @@ public class CodeRefTest {
 
 	private static final String FEATURE_CODE_REFERENCES = "src/test/resources/features/belly.feature:0";
 
-	private static final String SCENARIO_CODE_REFERENCES = "src/test/resources/features/belly.feature:4";
+	private static final String SCENARIO_CODE_REFERENCES = "src/test/resources/features/belly.feature:6";
 
 	@Test
 	public void verify_code_reference_scenario_reporter() {

--- a/src/test/java/com/epam/reportportal/cucumber/TestCaseIdTest.java
+++ b/src/test/java/com/epam/reportportal/cucumber/TestCaseIdTest.java
@@ -40,7 +40,11 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class TestCaseIdTest {
 
@@ -97,7 +101,7 @@ public class TestCaseIdTest {
 		verify(client, times(1)).startTestItem(same(testId), captor.capture());
 
 		StartTestItemRQ rq = captor.getValue();
-		assertThat(rq.getTestCaseId(), equalTo("src/test/resources/features/belly.feature:4"));
+		assertThat(rq.getTestCaseId(), equalTo("src/test/resources/features/belly.feature:6"));
 
 	}
 

--- a/src/test/resources/features/belly.feature
+++ b/src/test/resources/features/belly.feature
@@ -1,6 +1,8 @@
 Feature: Belly
 
   @ok
+  @issue:JIRA-1234
+  @issue:JIRA-5678
   Scenario: a few cukes
     Given I have 42 cukes in my belly
     When I wait 1 hour


### PR DESCRIPTION
Creates an ItemAttributesRQ from a single Tag-Annotation using the colon sign to separate key-value.

Examples: 
* "@MyTag" => new ItemAttributesRQ(null, "@MyTag")
* "@issue:JIRA-1234" => new ItemAttributesRQ("issue", "JIRA-1234")
* "@feature:SaveTheWorld" => new ItemAttributesRQ("feature", "SaveTheWorld")
* "@:@SomethingElse:SomeValue" (legacy support, in case you need a null key) => new ItemAttributesRQ(null, "@SomethingElse:SomeValue")

**Additional Info**: The splitting of the attributes is specially useful for the "Component health check" Widget.